### PR TITLE
Update manifest in advance of import

### DIFF
--- a/docs/1-introduction/index.md
+++ b/docs/1-introduction/index.md
@@ -1,4 +1,4 @@
-# About the WordPress documentation style guide
+# Introduction
 
 The WordPress Documentation Style Guide provides a set of rules and standards for writing developer and end-user documentation for any project related to WordPress.
 The primary objective of the WordPress Documentation Style Guide is to help authors write clear and accurate information while facilitating consistency across all documentation. The aim of this Style Guide is to accommodate the global WordPress community having varied skills and abilities.

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,20 @@
 {
 	"introduction": {
-		"title": "About the WordPress Documentation Style Guide",
-		"slug": "introduction",
+		"title": "Introduction",
+		"slug": "welcome",
 		"parent": null,
 		"order": 1,
 		"markdown_source": "https://github.com/WordPress/WordPress-Documentation-Style-Guide/blob/master/docs/1-introduction/index.md"
 	},
 	"introduction/highlights": {
 		"title": "Highlights",
-		"parent": "introduction",
+		"parent": "welcome",
 		"slug": "highlights",
 		"markdown_source": "https://github.com/WordPress/WordPress-Documentation-Style-Guide/blob/master/docs/1-introduction/highlights.md"
 	},
 	"introduction/changelog": {
 		"title": "Changelog",
-		"parent": "introduction",
+		"parent": "welcome",
 		"slug": "changelog",
 		"markdown_source": "https://github.com/WordPress/WordPress-Documentation-Style-Guide/blob/master/docs/1-introduction/changelog.md"
 	},
@@ -240,7 +240,7 @@
 	"punctuation/periods": {
 		"title": "Periods",
 		"parent": "punctuation",
-		"slug": "preiods",
+		"slug": "periods",
 		"markdown_source": "https://github.com/WordPress/WordPress-Documentation-Style-Guide/blob/master/docs/4-punctuation/periods.md"
 	},
 	"punctuation/question-marks": {
@@ -533,7 +533,7 @@
 		"title": "I",
 		"parent": "word-list",
 		"slug": "i",
-		"markdown_source": "https://github.com/WordPress/WordPress-Documentation-Style-Guide/blob/master/docs/8-word-list/I.md"
+		"markdown_source": "https://github.com/WordPress/WordPress-Documentation-Style-Guide/blob/master/docs/8-word-list/i.md"
 	},
 	"word-list/j": {
 		"title": "J",


### PR DESCRIPTION
I ran a preliminary import of the current manifest.json and spotted a few minor issues. This PR address them.

I will try my best to gett the Style Guide imported ASAP on Monday (for me, which is PST).

* Changes title for introduction page to simply "Introduction"
* Changes slug for introduction page to "welcome" (necessary to be detected as handbook's root page)
* Fixes typo in URL to `i.md` file
* Fixes typo in slug for "periods"