### PR TITLE
Replace left and right brackets in shortcode with HTML entities

### DIFF
--- a/docs/5-formatting/notices.md
+++ b/docs/5-formatting/notices.md
@@ -7,31 +7,31 @@
 To warn, alert, notify, or provide useful information to the reader that isn't part of the flow of text or needs to be highlighted, use one of the following notice types:
 
 - **Note** or **Info**  
-  Use this notice type for an informational note or message with the `[info][/info]` short code.  
+  Use this notice type for an informational note or message with the `&lbrack;info&rbrack;&lbrack;/info&rbrack;` short code.  
 
   **Example**  
   [info] **Note:** “Wide width” and “Full width” alignment need to be enabled by the theme of your site. [/info]  
 
 - **Tip**  
-  Use this notice type to highlight tips and recommended actions with the `[tip][/tip]` short code.  
+  Use this notice type to highlight tips and recommended actions with the `&lbrack;tip&rbrack;&lbrack;/tip&rbrack;` short code.  
 
   **Example**  
   [tip] **Tip:** You can use the slash command to insert a new block. [/tip]  
 
 - **Caution** or **Alert**  
-  Use this notice type to suggest readers to proceed with caution and alert them to important messages with the `[alert][/alert]` short code.
+  Use this notice type to suggest readers to proceed with caution and alert them to important messages with the `&lbrack;alert&rbrack;&lbrack;/alert&rbrack;` short code.
 
   **Example**  
   [alert] **Caution:** Using a deprecated version may cause different outcomes. [/alert]  
 
 - **Warning**  
-  When something is particularly precarious use this notice type with the `[warning][/warning]` short code. A warning is generally stricter and more rigid than a caution.
+  When something is particularly precarious use this notice type with the `&lbrack;warning&rbrack;&lbrack;/warning&rbrack;` short code. A warning is generally stricter and more rigid than a caution.
 
   **Example**  
   [warning] **Warning:** Making changes to the code while running the server could cause errors in your databases; specifically, corrupted tables or duplicate values. [/warning]  
 
 - **Tutorial** or **Step**  
-  Use this notice type to indicate a step or procedure in a tutorial with the `[tutorial][/tutorial]` short code.  
+  Use this notice type to indicate a step or procedure in a tutorial with the `&lbrack;tutorial&rbrack;&lbrack;/tutorial&rbrack;` short code.  
 
   **Example**  
   [tutorial] **Step:** Move the selected file to this folder. [/tutorial]  


### PR DESCRIPTION
Code samples are not visible in article because they are parsed as shordcode. We need to display shortcode as it would be used in the post. Hopefully, changing bracjets into respective HTML entities will prevent this from happening