### PR TITLE
Use `kbd` to keep apostrophe and quotation marks straight

### DIFF
--- a/docs/4-punctuation/apostrophes.md
+++ b/docs/4-punctuation/apostrophes.md
@@ -2,7 +2,7 @@
 
 [info] **Highlight:** Use straight apostrophes. [/info]  
 
-Use straight apostrophes, the same character as a single quotation mark ('). It is completely fine to use straight apostrophes in code snippets.
+Use straight apostrophes, the same character as a single quotation mark (<kbd>'</kbd>). It is completely fine to use straight apostrophes in code snippets.
 
 ## Apostrophes in contractions
 

--- a/docs/4-punctuation/quotation-marks.md
+++ b/docs/4-punctuation/quotation-marks.md
@@ -25,13 +25,13 @@ When you put a specific string, term, or phrase in quotation marks, put any punc
 
 ## Straight and curly quotation marks
 
-The direction of curly quotation marks (“ ”) and apostrophes are often confused while writing documentation. If you use straight quotation marks (" ") the trouble of tracking and writing the starting and closing curly quotation marks is eliminated. Code specifically needs straight quotation marks for its syntax, in addition to user input fields. Furthermore, not all software environments use curly quotation marks.
+The direction of curly quotation marks (“ ”) and apostrophes are often confused while writing documentation. If you use straight quotation marks (<kbd>"</kbd> <kbd>"</kbd>) the trouble of tracking and writing the starting and closing curly quotation marks is eliminated. Code specifically needs straight quotation marks for its syntax, in addition to user input fields. Furthermore, not all software environments use curly quotation marks.
 
-Hence, in general, use straight quotation marks (" ").
+Hence, in general, use straight quotation marks (<kbd>"</kbd> <kbd>"</kbd>).
 
 **Examples**  
 [warning] **Not recommended:** What does it mean if I see a message saying: “Error Code 345. Do you want to continue?” [/warning]  
-[tip] **Recommended:** What does it mean if I see a message saying: "Error Code 345. Do you want to continue?" [/tip]  
+[tip] **Recommended:** What does it mean if I see a message saying: <kbd>"</kbd>Error Code 345. Do you want to continue?<kbd>"</kbd> [/tip]  
 
 ## Single quotation marks
 


### PR DESCRIPTION
https://github.com/WordPress/Documentation-Issue-Tracker/issues/1848

Wraps single and double quote characters in `kbd` elements so the content filter should not convert them to curly quotes where the documentation explicitly instructs people to type the straight characters.
- [Apostrophes page](https://make.wordpress.org/docs/style-guide/punctuation/apostrophes/) 
- Quotation marks page, under [Straight and curly quotation marks](https://make.wordpress.org/docs/style-guide/punctuation/quotation-marks/#straight-and-curly-quotation-marks)