### PR TITLE
Fix incorrect article usage for “image” from Issue #2143

### DIFF
--- a/docs/5-formatting/media.md
+++ b/docs/5-formatting/media.md
@@ -20,9 +20,9 @@ Use images only when they provide visual information that is otherwise difficult
 
 ### Text associated with images
 
-In most cases, introduce an image with an introductory sentence that initiates the image that follows. If the heading of the content explains what the image is about, and no additional context is required, then don't include an introductory statement. You can introduce a image with an imperative statement.
+In most cases, introduce an image with an introductory sentence that initiates the image that follows. If the heading of the content explains what the image is about, and no additional context is required, then don't include an introductory statement. You can introduce an image with an imperative statement.
 
-The introductory sentence can end with a colon or a period. Use a period if the introductory content is extended, and a colon if the introductory statement is shorter and immediately precedes the image. The text preceding the colon must distinctly stand alone as a complete sentence. That is, don't introduce a image with a partial statement.
+The introductory sentence can end with a colon or a period. Use a period if the introductory content is extended, and a colon if the introductory statement is shorter and immediately precedes the image. The text preceding the colon must distinctly stand alone as a complete sentence. That is, don't introduce an image with a partial statement.
 
 There are different types of text associated with images. Alt text is a concise description of the image that can replace the image in situations when the image isn't visible as well as accessible documentation. For example, people using screen readers, people using text-only browsers or people having a low-bandwidth internet connection can benefit from alt text. Alt text should consider the context of the image, not just its content. For more information, see [alt attribute](https://wikipedia.org/wiki/Alt_attribute).
 


### PR DESCRIPTION
This pull request fixes incorrect article usage in the documentation by replacing “a image” with “an image” where applicable.

No functional or behavioral changes were made—this update is limited to grammar and readability improvements.

from Issue #2143