### PR TITLE
Fix link formatting in o.md

### DIFF
--- a/docs/8-word-list/o.md
+++ b/docs/8-word-list/o.md
@@ -96,7 +96,7 @@ Use *open*, not *start* or *launch* to describe opening a program, application, 
 
 Use *open*, not *opened*, to describe the open state, such as *an open folder*.
 
-For more information, see [Interaction verbs]https://make.wordpress.org/docs/style-guide/developer-content/ui-elements/#open).
+For more information, see [Interaction verbs](https://make.wordpress.org/docs/style-guide/developer-content/ui-elements/#open).
 
 See also [close](https://make.wordpress.org/docs/style-guide/word-list/c/#close).
 


### PR DESCRIPTION
Typo reported in Documentation Tracker for the page https://make.wordpress.org/docs/style-guide/word-list/o/#open

Closes: https://github.com/WordPress/Documentation-Issue-Tracker/issues/2505

props @abdullahkaludi @ahirpravin
 